### PR TITLE
Refactor swarm cleanup scripts and add deployment helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,75 @@
 # Swarm Cleanup
 
-This repository provides Bash utilities for deploying stacks and cleaning up unused Docker
-images in Swarm environments.
-
-`scripts/cleanup_docker_images.sh` removes unused Docker images and containers from a node.
-It works on both standalone Docker hosts and Swarm nodes. When executed on a Swarm manager
-it also protects images referenced by Swarm services.
+Utilities for deploying Docker Swarm stacks and removing unused Docker images.
+All scripts are written in Bash and include comments for easy maintenance.
 
 ## Requirements
 
 - Bash
 - Docker CLI available in `PATH`
-- Docker daemon reachable (and Swarm mode if you want service protections)
+- Access to a running Docker daemon (Swarm mode optional)
+
+## Script overview
+
+| Script | Description |
+|-------|-------------|
+| `scripts/cleanup_docker_images.sh` | Remove unused Docker images and containers on a node. |
+| `scripts/run_swarm_cleanup.sh` | Deploy a temporary stack that runs the cleanup script on every Swarm node. |
+| `deploy_and_cleanup.sh` | Deploy or update a Swarm stack, then trigger a cluster-wide cleanup. |
+| `ensure_swarm_cleanup_and_deploy.sh` | Ensure this repo exists locally and run `deploy_and_cleanup.sh` with your configuration. |
 
 ## Usage
 
-Run the script locally by providing the target repository via the `IMAGE_REPO`
-environment variable:
+### 1. Clean images on the current node
 
 ```bash
 IMAGE_REPO=myorg/myimage ./scripts/cleanup_docker_images.sh
 ```
 
-Set `DRY_RUN=1` to preview deletions without removing anything:
+Set `DRY_RUN=1` to preview deletions:
 
 ```bash
 IMAGE_REPO=myorg/myimage DRY_RUN=1 ./scripts/cleanup_docker_images.sh
 ```
 
-`RM_TIMEOUT` configures a timeout for each `docker rmi`/untag command (default `20s`).
-The script exits with an error if `IMAGE_REPO` is not specified.
-
-## Deploying a stack
-
-`deploy_and_cleanup.sh` deploys or updates a Docker Swarm stack and then runs the cleanup
-routine to remove unused images. It requires `IMAGE_REPO`, `STACK_NAME`, and `STACK_FILE`
-environment variables. `CLEANUP_STACK_FILE` and `CLEANUP_STACK_NAME` are optional and
-default to `docker/cleanup-stack.yml` and `swarm-cleanup` respectively.
-
-```bash
-IMAGE_REPO=myorg/myimage \\
-STACK_NAME=feedmama \\
-STACK_FILE=/path/to/stack.yml \\
-./deploy_and_cleanup.sh
-```
-
-The script pulls the specified image, deploys the stack (or updates existing services),
-and invokes `scripts/run_swarm_cleanup.sh` once the deployment is complete.
-
-## Running in Docker Swarm
-
-The repository also includes tooling to clean every node in a Swarm cluster.
-
-### Option 1: Convenience script
-
-Use `scripts/run_swarm_cleanup.sh` to deploy a temporary stack, wait for all cleanup tasks to finish, and then remove the stack automatically. It requires `IMAGE_REPO` and accepts optional `STACK_FILE` and `STACK_NAME` variables:
+### 2. Run cleanup on every Swarm node
 
 ```bash
 IMAGE_REPO=myorg/myimage ./scripts/run_swarm_cleanup.sh
 ```
 
-The stack file runs `scripts/cleanup_docker_images.sh` on each node.
+Optional variables:
+- `STACK_FILE` path to stack file (default `docker/cleanup-stack.yml`)
+- `STACK_NAME` name for the temporary stack (default `swarm-cleanup`)
 
-### Option 2: Manual stack deployment
-
-If you prefer manual control you can deploy the stack yourself:
+### 3. Deploy a stack and clean up old images
 
 ```bash
-IMAGE_REPO=myorg/myimage docker stack deploy \
-  -c docker/cleanup-stack.yml swarm-cleanup
-
-# after the tasks are finished
-docker stack rm swarm-cleanup
+IMAGE_REPO=myorg/myimage \
+STACK_NAME=my_stack \
+STACK_FILE=/path/to/stack.yml \
+./deploy_and_cleanup.sh
 ```
 
-The stack file clones this repository on each node at run time so you do not need to pre-distribute the script.
+### 4. Ensure repo and deploy
+
+`ensure_swarm_cleanup_and_deploy.sh` clones/updates this repository and runs `deploy_and_cleanup.sh`.
+Provide your stack details via environment variables:
+
+```bash
+IMAGE_REPO=myorg/myimage \
+STACK_NAME=my_stack \
+STACK_FILE=/root/docker/app-stack.yml \
+./ensure_swarm_cleanup_and_deploy.sh /root/run/swarm_cleanup main
+```
 
 ## Development
 
-Contributions are welcome. Please run `bash -n deploy_and_cleanup.sh scripts/*.sh` before submitting changes.
+Run basic syntax checks before submitting changes:
+
+```bash
+bash -n deploy_and_cleanup.sh scripts/*.sh ensure_swarm_cleanup_and_deploy.sh
+```
 
 ## License
 

--- a/deploy_and_cleanup.sh
+++ b/deploy_and_cleanup.sh
@@ -1,135 +1,132 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # deploy_and_cleanup.sh - Deploy or update a Docker Swarm stack and remove old images.
 #
 # Environment variables:
-#   IMAGE_TAG       - Image tag to deploy (default: latest)
-#   IMAGE_REPO      - Repository for the image (required)
-#   STACK_NAME      - Name of the stack (required)
-#   STACK_FILE      - Path to stack file (required)
-#   LOG_FILE        - Output log (default: /var/log/deploy_${STACK_NAME}.log)
-#   LOCK_FILE       - PID lock file (default: /tmp/deploy_${STACK_NAME}.pid)
-#   CLEANUP_SCRIPT     - Script to run after deployment (default: ./scripts/run_swarm_cleanup.sh)
-#   CLEANUP_STACK_FILE - Stack file used by the cleanup script (default: ./docker/cleanup-stack.yml)
-#   CLEANUP_STACK_NAME - Stack name used by the cleanup script (default: swarm-cleanup)
+#   IMAGE_TAG        Image tag to deploy (default: latest)
+#   IMAGE_REPO       Repository for the image (required)
+#   STACK_NAME       Name of the stack (required)
+#   STACK_FILE       Path to stack file (required)
+#   LOG_FILE         Output log (default: /var/log/deploy_${STACK_NAME}.log)
+#   LOCK_FILE        PID lock file (default: /tmp/deploy_${STACK_NAME}.pid)
+#   CLEANUP_SCRIPT      Script to run after deployment (default: ./scripts/run_swarm_cleanup.sh)
+#   CLEANUP_STACK_FILE  Stack file used by the cleanup script (default: ./docker/cleanup-stack.yml)
+#   CLEANUP_STACK_NAME  Stack name used by the cleanup script (default: swarm-cleanup)
 
-IMAGE_TAG="${IMAGE_TAG:-latest}"
-IMAGE_REPO="${IMAGE_REPO:-}"
-STACK_NAME="${STACK_NAME:-}"
-STACK_FILE="${STACK_FILE:-}"
-LOG_FILE="${LOG_FILE:-/var/log/deploy_${STACK_NAME}_uniq.log}"
-LOCK_FILE="${LOCK_FILE:-/tmp/deploy_${STACK_NAME}_uniq.pid}"
-SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-CLEANUP_SCRIPT="${CLEANUP_SCRIPT:-$SCRIPT_DIR/scripts/run_swarm_cleanup.sh}"
-CLEANUP_STACK_FILE="${CLEANUP_STACK_FILE:-$SCRIPT_DIR/docker/cleanup-stack.yml}"
-CLEANUP_STACK_NAME="${CLEANUP_STACK_NAME:-swarm-cleanup}"
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$STACK_NAME|$IMAGE_TAG] $1"; }
+require() { command -v "$1" >/dev/null 2>&1 || { echo "command not found: $1" >&2; exit 1; }; }
 
-if [[ -z "$IMAGE_REPO" || -z "$STACK_NAME" || -z "$STACK_FILE" ]]; then
-  echo "IMAGE_REPO, STACK_NAME and STACK_FILE must be set" >&2
-  exit 1
-fi
+main() {
+  IMAGE_TAG="${IMAGE_TAG:-latest}"
+  IMAGE_REPO="${IMAGE_REPO:-}"
+  STACK_NAME="${STACK_NAME:-}"
+  STACK_FILE="${STACK_FILE:-}"
+  LOG_FILE="${LOG_FILE:-/var/log/deploy_${STACK_NAME}.log}"
+  LOCK_FILE="${LOCK_FILE:-/tmp/deploy_${STACK_NAME}.pid}"
+  SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+  CLEANUP_SCRIPT="${CLEANUP_SCRIPT:-$SCRIPT_DIR/scripts/run_swarm_cleanup.sh}"
+  CLEANUP_STACK_FILE="${CLEANUP_STACK_FILE:-$SCRIPT_DIR/docker/cleanup-stack.yml}"
+  CLEANUP_STACK_NAME="${CLEANUP_STACK_NAME:-swarm-cleanup}"
 
-# Kill old deploy process if running
-if [[ -f "$LOCK_FILE" ]]; then
-  PREV_PID=$(cat "$LOCK_FILE")
-  if ps -p "$PREV_PID" > /dev/null 2>&1; then
-    echo "⚠️ Killing old deploy process (PID $PREV_PID)..."
-    kill "$PREV_PID" || true
-    sleep 2
-  fi
-  rm -f "$LOCK_FILE"
-fi
-
-(
-  echo $$ > "$LOCK_FILE"
-  trap 'rm -f "$LOCK_FILE"' EXIT
-
-  set -euo pipefail
-
-  # Load environment variables from system
-  set -a
-  source /etc/environment 2>/dev/null || true
-  set +a
-
-  log_message() {
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$STACK_NAME|$IMAGE_TAG] $1"
-  }
-
-  START_TS=$(date +%s)
-
-  log_message "🚀 Deploying stack: $STACK_NAME"
-  log_message "📦 Using image: $IMAGE_REPO:$IMAGE_TAG"
-  log_message "📄 Stack file: $STACK_FILE"
-
-  IMAGE_REF="$IMAGE_REPO:$IMAGE_TAG"
-
-  log_message "📥 Pulling image: $IMAGE_REF"
-  if ! docker pull "$IMAGE_REF" > /dev/null 2>&1; then
-    log_message "[❌] Failed to pull image: $IMAGE_REF"
+  if [[ -z "$IMAGE_REPO" || -z "$STACK_NAME" || -z "$STACK_FILE" ]]; then
+    echo "IMAGE_REPO, STACK_NAME and STACK_FILE must be set" >&2
     exit 1
   fi
 
-  if [[ "$IMAGE_TAG" == "latest" ]]; then
-    log_message "🔍 Resolving digest for latest tag..."
-    IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE_REF" 2>/dev/null || true)
-    if [[ -z "$IMAGE_DIGEST" ]]; then
-      log_message "[❌] Failed to resolve digest for $IMAGE_REF"
-      exit 1
+  require docker
+
+  if [[ -f "$LOCK_FILE" ]]; then
+    prev_pid=$(cat "$LOCK_FILE")
+    if ps -p "$prev_pid" >/dev/null 2>&1; then
+      echo "⚠️ Killing old deploy process (PID $prev_pid)..."
+      kill "$prev_pid" || true
+      sleep 2
     fi
-    IMAGE_REF="$IMAGE_DIGEST"
-    log_message "✅ Using digest: $IMAGE_REF"
-  else
-    log_message "✅ Using specific tag: $IMAGE_REF"
+    rm -f "$LOCK_FILE"
   fi
 
-  UPDATE_SERVICES=true
-  if [[ -z $(docker stack services "$STACK_NAME" --format '{{.Name}}') ]]; then
-    log_message "⚙️ Stack '$STACK_NAME' is missing. Deploying from scratch..."
-    if ! IMAGE_NAME="$IMAGE_REF" docker stack deploy -c "$STACK_FILE" --with-registry-auth "$STACK_NAME" > /dev/null 2>&1; then
-      log_message "[❌] Failed to deploy stack: $STACK_NAME"
+  (
+    echo $$ > "$LOCK_FILE"
+    trap 'rm -f "$LOCK_FILE"' EXIT
+    set -euo pipefail
+    START_TS=$(date +%s)
+
+    set -a
+    source /etc/environment 2>/dev/null || true
+    set +a
+
+    log "🚀 Deploying stack: $STACK_NAME"
+    log "📦 Using image: $IMAGE_REPO:$IMAGE_TAG"
+    log "📄 Stack file: $STACK_FILE"
+
+    image_ref="$IMAGE_REPO:$IMAGE_TAG"
+    log "📥 Pulling image: $image_ref"
+    if ! docker pull "$image_ref" >/dev/null 2>&1; then
+      log "[❌] Failed to pull image: $image_ref"
       exit 1
     fi
-    log_message "✅ Stack deployed successfully."
-    UPDATE_SERVICES=false
-  else
-    log_message "✅ Stack is running. Proceeding to update services..."
-  fi
 
-  STACK_SERVICES=($(docker stack services "$STACK_NAME" --format '{{.Name}}'))
-
-  if $UPDATE_SERVICES; then
-    for SERVICE_NAME in "${STACK_SERVICES[@]}"; do
-      if ! docker service inspect "$SERVICE_NAME" > /dev/null 2>&1; then
-        log_message "[⚠️] Skipping not found service: $SERVICE_NAME"
-        continue
-      fi
-
-      log_message "🔄 Updating service: $SERVICE_NAME"
-      if docker service update --image "$IMAGE_REF" --force "$SERVICE_NAME" > /dev/null 2>&1; then
-        log_message "✅ Done updating: $SERVICE_NAME"
-      else
-        log_message "[❌] Failed to update: $SERVICE_NAME"
+    if [[ "$IMAGE_TAG" == "latest" ]]; then
+      log "🔍 Resolving digest for latest tag..."
+      image_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "$image_ref" 2>/dev/null || true)
+      if [[ -z "$image_digest" ]]; then
+        log "[❌] Failed to resolve digest for $image_ref"
         exit 1
       fi
-    done
-    log_message "✅ All services updated with image: $IMAGE_REF"
-  else
-    log_message "ℹ️ Skipped update — stack was just deployed."
-  fi
+      image_ref="$image_digest"
+      log "✅ Using digest: $image_ref"
+    else
+      log "✅ Using specific tag: $image_ref"
+    fi
 
-  DEPLOY_DURATION=$(( $(date +%s) - START_TS ))
-  log_message "🏁 Deploy completed in ${DEPLOY_DURATION}s"
+    update_services=true
+    if [[ -z $(docker stack services "$STACK_NAME" --format '{{.Name}}') ]]; then
+      log "⚙️ Stack '$STACK_NAME' is missing. Deploying from scratch..."
+      if ! IMAGE_NAME="$image_ref" docker stack deploy -c "$STACK_FILE" --with-registry-auth "$STACK_NAME" >/dev/null 2>&1; then
+        log "[❌] Failed to deploy stack: $STACK_NAME"
+        exit 1
+      fi
+      log "✅ Stack deployed successfully."
+      update_services=false
+    else
+      log "✅ Stack is running. Proceeding to update services..."
+    fi
 
-  # Ensure cleanup script is executable
-  if [[ -f "$CLEANUP_SCRIPT" && -x "$CLEANUP_SCRIPT" ]]; then
-    log_message "⏳ Waiting 30s before cleanup..."
-    sleep 30
-    log_message "🧹 Running swarm image cleanup..."
-    STACK_FILE="$CLEANUP_STACK_FILE" STACK_NAME="$CLEANUP_STACK_NAME" IMAGE_REPO="$IMAGE_REPO" bash "$CLEANUP_SCRIPT" >> "$LOG_FILE" 2>&1
-    log_message "✅ Swarm image cleanup finished..."
-  else
-    log_message "[⚠️] Cleanup script not found or not executable: $CLEANUP_SCRIPT"
-  fi
+    stack_services=($(docker stack services "$STACK_NAME" --format '{{.Name}}'))
 
-) >> "$LOG_FILE" 2>&1 &
+    if $update_services; then
+      for service_name in "${stack_services[@]}"; do
+        if ! docker service inspect "$service_name" >/dev/null 2>&1; then
+          log "[⚠️] Skipping not found service: $service_name"
+          continue
+        fi
+        log "🔄 Updating service: $service_name"
+        if docker service update --image "$image_ref" --force "$service_name" >/dev/null 2>&1; then
+          log "✅ Done updating: $service_name"
+        else
+          log "[❌] Failed to update: $service_name"
+          exit 1
+        fi
+      done
+      log "✅ All services updated with image: $image_ref"
+    else
+      log "ℹ️ Skipped update — stack was just deployed."
+    fi
+
+    deploy_duration=$(( $(date +%s) - START_TS ))
+    log "🏁 Deploy completed in ${deploy_duration}s"
+
+    if [[ -f "$CLEANUP_SCRIPT" && -x "$CLEANUP_SCRIPT" ]]; then
+      log "⏳ Waiting 30s before cleanup..."
+      sleep 30
+      log "🧹 Running swarm image cleanup..."
+      STACK_FILE="$CLEANUP_STACK_FILE" STACK_NAME="$CLEANUP_STACK_NAME" IMAGE_REPO="$IMAGE_REPO" bash "$CLEANUP_SCRIPT" >> "$LOG_FILE" 2>&1
+      log "✅ Swarm image cleanup finished..."
+    else
+      log "[⚠️] Cleanup script not found or not executable: $CLEANUP_SCRIPT"
+    fi
+  ) >> "$LOG_FILE" 2>&1 &
+}
+
+main "$@"

--- a/docker/cleanup-stack.yml
+++ b/docker/cleanup-stack.yml
@@ -1,3 +1,4 @@
+# Docker Swarm stack that runs the cleanup script on every node
 services:
   swarm_cleanup:
     image: alpine:3.19

--- a/ensure_swarm_cleanup_and_deploy.sh
+++ b/ensure_swarm_cleanup_and_deploy.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# ensure_swarm_cleanup_and_deploy.sh
+#
+# Purpose:
+#   - Ensure the public repo "swarm_cleanup" exists locally (HTTPS clone).
+#   - If the remote branch has a newer commit, re-clone a fresh copy (atomic replace).
+#   - Run the repo's ./deploy_and_cleanup.sh with the provided ENV configuration.
+#
+# Usage:
+#   ./ensure_swarm_cleanup_and_deploy.sh [TARGET_DIR] [BRANCH]
+#
+#   TARGET_DIR (optional) : destination directory (default: /root/run/swarm_cleanup)
+#   BRANCH     (optional) : git branch to track (default: main)
+#
+# Environment variables (with sane defaults):
+#   IMAGE_TAG   : image tag to deploy (default: latest)
+#   IMAGE_REPO  : image repo (default: myorg/myapp)
+#   STACK_NAME  : stack name (default: app_stack)
+#   STACK_FILE  : stack file path (default: /root/docker/app-stack.yml)
+#
+# Notes:
+#   - Designed to be idempotent and safe to re-run.
+#   - Uses only public HTTPS clone (no SSH or tokens required for public repos).
+#   - Keep logic small, testable, and easy to extend.
+
+set -euo pipefail
+
+# -------- Config (defaults) --------
+REPO_URL="https://github.com/tanngoc93/swarm_cleanup.git"
+TARGET_DIR="${1:-/root/run/swarm_cleanup}"
+BRANCH="${2:-main}"
+
+# Deployment ENV (can be overridden by caller)
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+IMAGE_REPO="${IMAGE_REPO:-myorg/myapp}"
+STACK_NAME="${STACK_NAME:-app_stack}"
+STACK_FILE="${STACK_FILE:-/root/docker/app-stack.yml}"
+
+# -------- Utilities --------
+log() { printf "[%s] %s\n" "$(date '+%F %T')" "$*"; }
+
+abort() {
+  log "❌ $*"
+  exit 1
+}
+
+require() {
+  # Ensure a required command exists
+  command -v "$1" >/dev/null 2>&1 || abort "'$1' is not installed"
+}
+
+get_remote_head() {
+  # Return the commit hash of the remote branch (empty on failure)
+  git ls-remote --heads "$REPO_URL" "$BRANCH" 2>/dev/null | awk '{print $1}'
+}
+
+get_local_head() {
+  # Return local HEAD hash (empty if not a valid repo)
+  [[ -d "$TARGET_DIR/.git" ]] || { echo ""; return; }
+  git -C "$TARGET_DIR" rev-parse HEAD 2>/dev/null || echo ""
+}
+
+ensure_executable_if_exists() {
+  # Make a file executable if it exists (no error if missing)
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    chmod +x "$path" || true
+    log "🔧 Ensured executable: $path"
+  fi
+}
+
+clone_fresh() {
+  # Clone into a temp dir, then atomically replace TARGET_DIR
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  log "⬇️  Cloning $REPO_URL (branch: $BRANCH) into a temporary directory..."
+  git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$tmpdir/repo"
+  log "✅ Clone completed."
+
+  # Make commonly used scripts executable (idempotent)
+  ensure_executable_if_exists "$tmpdir/repo/scripts/run_swarm_cleanup.sh"
+  ensure_executable_if_exists "$tmpdir/repo/deploy_and_cleanup.sh"
+
+  # Atomic replace
+  mkdir -p "$(dirname "$TARGET_DIR")"
+  if [[ -e "$TARGET_DIR" ]]; then
+    log "♻️  Replacing existing directory: $TARGET_DIR"
+    rm -rf "$TARGET_DIR"
+  fi
+  mv "$tmpdir/repo" "$TARGET_DIR"
+  rmdir "$tmpdir" 2>/dev/null || true
+
+  log "🏁 Repo ready at: $TARGET_DIR"
+}
+
+run_deploy() {
+  # Execute deploy_and_cleanup.sh with the configured ENV
+  local deploy_script="$TARGET_DIR/deploy_and_cleanup.sh"
+  [[ -x "$deploy_script" ]] || abort "$deploy_script not found or not executable"
+
+  log "🚀 Running deploy_and_cleanup.sh with ENV:"
+  log "    IMAGE_TAG  = $IMAGE_TAG"
+  log "    IMAGE_REPO = $IMAGE_REPO"
+  log "    STACK_NAME = $STACK_NAME"
+  log "    STACK_FILE = $STACK_FILE"
+
+  IMAGE_TAG="$IMAGE_TAG" \
+  IMAGE_REPO="$IMAGE_REPO" \
+  STACK_NAME="$STACK_NAME" \
+  STACK_FILE="$STACK_FILE" \
+  "$deploy_script"
+}
+
+# -------- Main flow --------
+main() {
+  require git
+
+  # 1) Resolve remote HEAD
+  local remote_head
+  remote_head="$(get_remote_head)"
+  [[ -n "$remote_head" ]] || abort "Unable to resolve remote head for $REPO_URL (branch: $BRANCH)"
+
+  # 2) Clone or refresh if outdated
+  if [[ ! -d "$TARGET_DIR/.git" ]]; then
+    log "ℹ️  Local repo not found at $TARGET_DIR. Cloning fresh..."
+    clone_fresh
+  else
+    local local_head
+    local_head="$(get_local_head)"
+    if [[ -z "$local_head" ]]; then
+      log "⚠️  $TARGET_DIR exists but is not a valid git repo. Cloning fresh..."
+      clone_fresh
+    elif [[ "$local_head" != "$remote_head" ]]; then
+      log "🆕 Remote is newer:"
+      log "    local : $local_head"
+      log "    remote: $remote_head"
+      log "➡️  Re-cloning a fresh copy..."
+      clone_fresh
+    else
+      log "✅ Repo is up to date."
+      # Still ensure scripts are executable (idempotent)
+      ensure_executable_if_exists "$TARGET_DIR/scripts/run_swarm_cleanup.sh"
+      ensure_executable_if_exists "$TARGET_DIR/deploy_and_cleanup.sh"
+    fi
+  fi
+
+  # 3) Run deployment
+  run_deploy
+}
+
+main "$@"

--- a/scripts/run_swarm_cleanup.sh
+++ b/scripts/run_swarm_cleanup.sh
@@ -1,50 +1,57 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # run_swarm_cleanup.sh - deploy a temporary stack to clean unused images on all nodes.
 #
 # Environment variables:
-#   IMAGE_REPO - Repository to clean (required)
-#   STACK_FILE - Path to the cleanup stack file (default: ../docker/cleanup-stack.yml)
-#   STACK_NAME - Name of the cleanup stack (default: swarm-cleanup)
+#   IMAGE_REPO  - Repository to clean (required)
+#   STACK_FILE  - Path to the cleanup stack file (default: ../docker/cleanup-stack.yml)
+#   STACK_NAME  - Name of the cleanup stack (default: swarm-cleanup)
 
-SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-STACK_FILE="${STACK_FILE:-$SCRIPT_DIR/../docker/cleanup-stack.yml}"
-STACK_NAME="${STACK_NAME:-swarm-cleanup}"
-IMAGE_REPO="${IMAGE_REPO:-}"
+log() { printf '%s\n' "$*"; }
+require() { command -v "$1" >/dev/null 2>&1 || { log "command not found: $1"; exit 1; }; }
 
-if [[ -z "$IMAGE_REPO" ]]; then
-  echo "IMAGE_REPO must be set" >&2
-  exit 1
-fi
+main() {
+  require docker
 
-if [[ ! -f "$STACK_FILE" ]]; then
-  echo "Stack file not found: $STACK_FILE" >&2
-  exit 1
-fi
+  local script_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+  local stack_file="${STACK_FILE:-$script_dir/../docker/cleanup-stack.yml}"
+  local stack_name="${STACK_NAME:-swarm-cleanup}"
+  local image_repo="${IMAGE_REPO:-}"
 
-echo "🚀 Deploy cleanup stack..."
-RUN_TIMESTAMP=$(date +%s) IMAGE_REPO="$IMAGE_REPO" docker stack deploy -c "$STACK_FILE" "$STACK_NAME"
-
-echo "⏳ Waiting for cleanup tasks..."
-while true; do
-  TASK_STATE=$(docker service ps "${STACK_NAME}_swarm_cleanup" \
-    --no-trunc --format "{{.CurrentState}}" 2>/dev/null | head -n1)
-
-  echo "State: $TASK_STATE"
-
-  if [[ "$TASK_STATE" == *"Complete"* ]] || [[ "$TASK_STATE" == *"Shutdown"* ]]; then
-    echo "✅ Cleanup finished"
-    break
+  if [[ -z "$image_repo" ]]; then
+    log "IMAGE_REPO must be set"
+    exit 1
   fi
 
-  if [[ "$TASK_STATE" == *"Failed"* ]]; then
-    echo "❌ Cleanup failed"
-    break
+  if [[ ! -f "$stack_file" ]]; then
+    log "Stack file not found: $stack_file"
+    exit 1
   fi
 
-  sleep 3
-done
+  log "🚀 Deploy cleanup stack..."
+  RUN_TIMESTAMP=$(date +%s) IMAGE_REPO="$image_repo" docker stack deploy -c "$stack_file" "$stack_name"
 
-echo "🧹 Removing stack..."
-docker stack rm "$STACK_NAME"
+  log "⏳ Waiting for cleanup tasks..."
+  while true; do
+    task_state=$(docker service ps "${stack_name}_swarm_cleanup" --no-trunc --format "{{.CurrentState}}" 2>/dev/null | head -n1)
+    log "State: $task_state"
+
+    if [[ "$task_state" == *"Complete"* ]] || [[ "$task_state" == *"Shutdown"* ]]; then
+      log "✅ Cleanup finished"
+      break
+    fi
+
+    if [[ "$task_state" == *"Failed"* ]]; then
+      log "❌ Cleanup failed"
+      break
+    fi
+
+    sleep 3
+  done
+
+  log "🧹 Removing stack..."
+  docker stack rm "$stack_name"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- refactor Bash scripts with clearer structure and logging
- add `ensure_swarm_cleanup_and_deploy.sh` helper to clone/update repo and run deployment
- rewrite README for simpler usage guidance

## Testing
- `bash -n deploy_and_cleanup.sh scripts/*.sh ensure_swarm_cleanup_and_deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b92fa734f8832ba816b4648f76efb0