### PR TITLE
refactor: generic target directory in ensure_swarm script

### DIFF
--- a/ensure_swarm_cleanup_and_deploy.sh
+++ b/ensure_swarm_cleanup_and_deploy.sh
@@ -9,7 +9,7 @@
 # Usage:
 #   ./ensure_swarm_cleanup_and_deploy.sh [TARGET_DIR] [BRANCH]
 #
-#   TARGET_DIR (optional) : destination directory (default: /root/run/swarm_cleanup)
+#   TARGET_DIR (optional) : destination directory (default: $HOME/run/swarm_cleanup)
 #   BRANCH     (optional) : git branch to track (default: main)
 #
 # Environment variables (with sane defaults):
@@ -27,7 +27,7 @@ set -euo pipefail
 
 # -------- Config (defaults) --------
 REPO_URL="https://github.com/tanngoc93/swarm_cleanup.git"
-TARGET_DIR="${1:-/root/run/swarm_cleanup}"
+TARGET_DIR="${1:-$HOME/run/swarm_cleanup}"
 BRANCH="${2:-main}"
 
 # Deployment ENV (can be overridden by caller)


### PR DESCRIPTION
## Summary
- default target dir now uses $HOME instead of /root

## Testing
- `bash -n ensure_swarm_cleanup_and_deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9381eae88832b92877b13f2f0349e