### PR TITLE
docs: simplify README for Swarm service usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,65 @@
 # Swarm Cleanup
 
-Utilities for deploying Docker Swarm stacks and removing unused Docker images.
-All scripts are written in Bash and include comments for easy maintenance.
+Công cụ nhỏ gọn giúp triển khai stack lên Docker Swarm và dọn dẹp các image không còn sử dụng.
 
-## Requirements
+## Yêu cầu
 
+- Docker đã cài đặt và bật chế độ Swarm
+- Có quyền chạy lệnh Docker
 - Bash
-- Docker CLI available in `PATH`
-- Access to a running Docker daemon (Swarm mode optional)
 
-## Script overview
+## Cấu hình
 
-| Script | Description |
-|-------|-------------|
-| `scripts/cleanup_docker_images.sh` | Remove unused Docker images and containers on a node. |
-| `scripts/run_swarm_cleanup.sh` | Deploy a temporary stack that runs the cleanup script on every Swarm node. |
-| `deploy_and_cleanup.sh` | Deploy or update a Swarm stack, then trigger a cluster-wide cleanup. |
-| `ensure_swarm_cleanup_and_deploy.sh` | Ensure this repo exists locally and run `deploy_and_cleanup.sh` with your configuration. |
+1. **Tạo file stack**  
+   Viết file mô tả stack của bạn, ví dụ: `/root/docker/app-stack.yml`.
 
-## Usage
+2. **Khai báo biến môi trường**  
+   Đặt thông tin cho stack và image sẽ triển khai:
 
-### 1. Clean images on the current node
+   ```bash
+   export IMAGE_REPO=myorg/myimage        # bắt buộc
+   export STACK_NAME=my_stack             # bắt buộc
+   export STACK_FILE=/root/docker/app-stack.yml  # bắt buộc
+   export IMAGE_TAG=latest                # tùy chọn, mặc định latest
+   ```
 
-```bash
-IMAGE_REPO=myorg/myimage ./scripts/cleanup_docker_images.sh
-```
+## Chạy deploy và cleanup
 
-Set `DRY_RUN=1` to preview deletions:
+### Đã có repo local
 
-```bash
-IMAGE_REPO=myorg/myimage DRY_RUN=1 ./scripts/cleanup_docker_images.sh
-```
-
-### 2. Run cleanup on every Swarm node
+Trong thư mục chứa repo, chạy:
 
 ```bash
-IMAGE_REPO=myorg/myimage ./scripts/run_swarm_cleanup.sh
-```
-
-Optional variables:
-- `STACK_FILE` path to stack file (default `docker/cleanup-stack.yml`)
-- `STACK_NAME` name for the temporary stack (default `swarm-cleanup`)
-
-### 3. Deploy a stack and clean up old images
-
-```bash
-IMAGE_REPO=myorg/myimage \
-STACK_NAME=my_stack \
-STACK_FILE=/path/to/stack.yml \
+IMAGE_REPO=$IMAGE_REPO \
+STACK_NAME=$STACK_NAME \
+STACK_FILE=$STACK_FILE \
+IMAGE_TAG=${IMAGE_TAG:-latest} \
 ./deploy_and_cleanup.sh
 ```
 
-### 4. Ensure repo and deploy
+### Chưa có repo local
 
-`ensure_swarm_cleanup_and_deploy.sh` clones/updates this repository and runs `deploy_and_cleanup.sh`.
-Provide your stack details via environment variables:
+`ensure_swarm_cleanup_and_deploy.sh` sẽ tự clone hoặc cập nhật repo rồi chạy deploy:
 
 ```bash
-IMAGE_REPO=myorg/myimage \
-STACK_NAME=my_stack \
-STACK_FILE=/root/docker/app-stack.yml \
+IMAGE_REPO=$IMAGE_REPO \
+STACK_NAME=$STACK_NAME \
+STACK_FILE=$STACK_FILE \
+IMAGE_TAG=${IMAGE_TAG:-latest} \
 ./ensure_swarm_cleanup_and_deploy.sh /root/run/swarm_cleanup main
 ```
 
-## Development
+Script sẽ clone repo (nếu cần), triển khai stack, chờ 30 giây rồi dọn dẹp image cũ trên toàn cluster.
 
-Run basic syntax checks before submitting changes:
+## Kiểm tra
+
+Sau khi chỉnh sửa mã, chạy kiểm tra cú pháp:
 
 ```bash
 bash -n deploy_and_cleanup.sh scripts/*.sh ensure_swarm_cleanup_and_deploy.sh
 ```
 
-## License
+## Giấy phép
 
-This project is provided under the MIT License.
+MIT License
+


### PR DESCRIPTION
## Summary
- Rewrite README in Vietnamese with a concise workflow for configuring a stack file and running deployment/cleanup scripts on Docker Swarm.

## Testing
- `bash -n deploy_and_cleanup.sh scripts/*.sh ensure_swarm_cleanup_and_deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b94b9795d4832ba5b5a8232562246a