### PR TITLE
Move rollback script to root with consistent ENV config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
   - `STACK_FILE` path to stack file (default `docker/cleanup-stack.yml`)
   - `STACK_NAME` name for the temporary stack (default `swarm-cleanup`)
 
-- **Roll back to a previous image digest**
-  ```bash
-  STACK_NAME=my_stack IMAGE_REPO=myorg/myimage ./scripts/manual_rollback.sh
-  ```
+ - **Roll back to a previous image digest**
+   ```bash
+   STACK_NAME=my_stack IMAGE_REPO=myorg/myimage ./manual_rollback.sh
+   ```
 
 - **Ensure repo and deploy**
   Clone or update this repo and run `deploy_and_cleanup.sh` in one step:
@@ -77,7 +77,7 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
 Run basic syntax checks before submitting changes:
 
 ```bash
-bash -n deploy_and_cleanup.sh scripts/*.sh ensure_swarm_cleanup_and_deploy.sh
+bash -n deploy_and_cleanup.sh manual_rollback.sh scripts/*.sh ensure_swarm_cleanup_and_deploy.sh
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- relocate manual rollback script to repository root
- align rollback script's ENV defaults with deploy script
- update documentation and dev checks for new rollback path

## Testing
- `bash -n deploy_and_cleanup.sh manual_rollback.sh scripts/*.sh ensure_swarm_cleanup_and_deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b95d814594832b9c896fca72a92793