### PR TITLE
Store swarm image digest logs in dedicated folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Deployment digest logs
+digests/
 *_image_digests.log
 

--- a/manual_rollback.sh
+++ b/manual_rollback.sh
@@ -10,15 +10,16 @@ set -euo pipefail
 # Environment variables (with defaults):
 #   IMAGE_REPO    Image repository (default: myorg/myapp)
 #   STACK_NAME    Stack name (default: app_stack)
-#   DIGEST_FILE   File storing digests (default: ./app_stack_image_digests.log)
+#   DIGEST_DIR    Directory storing digest logs (default: ./digests)
+#   DIGEST_FILE   File storing digests (default: ./digests/app_stack_image_digests.log)
 #   TARGET_DIGEST Digest to roll back to (optional; prompts if unset)
 
 # -------- Config (defaults) --------
 IMAGE_REPO="${IMAGE_REPO:-myorg/myapp}"
 STACK_NAME="${STACK_NAME:-app_stack}"
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-ROOT_DIR="$SCRIPT_DIR"
-DIGEST_FILE="${DIGEST_FILE:-$ROOT_DIR/${STACK_NAME}_image_digests.log}"
+DIGEST_DIR="${DIGEST_DIR:-$SCRIPT_DIR/digests}"
+DIGEST_FILE="${DIGEST_FILE:-$DIGEST_DIR/${STACK_NAME}_image_digests.log}"
 TARGET_DIGEST="${TARGET_DIGEST:-}"
 LOG_TAG="rollback"
 


### PR DESCRIPTION
## Summary
- add `DIGEST_DIR` to deploy script and log image digests under `./digests`
- read digest logs from the same directory in `manual_rollback.sh`
- ignore generated digest log directory in git

## Testing
- `bash -n deploy_and_cleanup.sh manual_rollback.sh scripts/*.sh ensure_swarm_cleanup_and_deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9607fae7c832b811cd9c4bc3f2878