### PR TITLE
Update repo references to swarm-stackhouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
 
 1. **Create a deployment script**
 
-   On the Swarm manager node, create a shell script such as `deploy_swarm.sh` and copy the contents of `ensure_swarm_cleanup_and_deploy.sh` from this repository into it. Make the script executable:
+   On the Swarm manager node, create a shell script such as `deploy_swarm.sh` and copy the contents of `ensure_swarm_stackhouse_and_deploy.sh` from this repository into it. Make the script executable:
 
    ```bash
    chmod +x deploy_swarm.sh
@@ -26,7 +26,7 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
    To roll back manually, create another script (e.g. `rollback_swarm.sh`) containing:
 
    ```bash
-   IMAGE_REPO=myorg/myapp STACK_NAME=app_stack bash /tmp/swarm_cleanup/manual_rollback.sh
+   IMAGE_REPO=myorg/myapp STACK_NAME=app_stack bash /tmp/swarm-stackhouse/manual_rollback.sh
    ```
 
    Make it executable with `chmod +x rollback_swarm.sh`.
@@ -39,7 +39,7 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
    IMAGE_TAG=v1 ./deploy_swarm.sh
    ```
 
-   The script clones or updates this repository at `/tmp/swarm_cleanup`, deploys the specified stack, and removes unused images across the cluster.
+   The script clones or updates this repository at `/tmp/swarm-stackhouse`, deploys the specified stack, and removes unused images across the cluster.
 
 ## Requirements
 
@@ -52,7 +52,7 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
 Run basic syntax checks before submitting changes:
 
 ```bash
-bash -n deploy_and_cleanup.sh manual_rollback.sh scripts/*.sh ensure_swarm_cleanup_and_deploy.sh
+bash -n deploy_and_cleanup.sh manual_rollback.sh scripts/*.sh ensure_swarm_stackhouse_and_deploy.sh
 ```
 
 ## License

--- a/docker/cleanup-stack.yml
+++ b/docker/cleanup-stack.yml
@@ -3,8 +3,8 @@ services:
   swarm_cleanup:
     image: alpine:3.19
     environment:
-      REPO_URL: "${REPO_URL:-https://github.com/tanngoc93/swarm_cleanup.git}"
-      REPO_DIR: "${REPO_DIR:-/tmp/swarm_cleanup}"
+      REPO_URL: "${REPO_URL:-https://github.com/tanngoc93/swarm-stackhouse.git}"
+      REPO_DIR: "${REPO_DIR:-/tmp/swarm-stackhouse}"
       SCRIPT: "${SCRIPT:-scripts/cleanup_docker_images.sh}"
       IMAGE_REPO: "${IMAGE_REPO}"
       DRY_RUN: "${DRY_RUN:-0}"

--- a/ensure_swarm_stackhouse_and_deploy.sh
+++ b/ensure_swarm_stackhouse_and_deploy.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# ensure_swarm_cleanup_and_deploy.sh
+# ensure_swarm_stackhouse_and_deploy.sh
 #
 # Purpose:
-#   - Ensure the public repo "swarm_cleanup" exists locally (HTTPS clone).
+#   - Ensure the public repo "swarm-stackhouse" exists locally (HTTPS clone).
 #   - If the remote branch has a newer commit, re-clone a fresh copy (atomic replace).
 #   - Run the repo's ./deploy_and_cleanup.sh with the provided ENV configuration.
 #
 # Usage:
-#   ./ensure_swarm_cleanup_and_deploy.sh [TARGET_DIR] [BRANCH]
+#   ./ensure_swarm_stackhouse_and_deploy.sh [TARGET_DIR] [BRANCH]
 #
-#   TARGET_DIR (optional) : destination directory (default: /tmp/swarm_cleanup)
+#   TARGET_DIR (optional) : destination directory (default: /tmp/swarm-stackhouse)
 #   BRANCH     (optional) : git branch to track (default: main)
 #
 # Environment variables (with sane defaults):
@@ -26,8 +26,8 @@
 set -euo pipefail
 
 # -------- Config (defaults) --------
-REPO_URL="https://github.com/tanngoc93/swarm_cleanup.git"
-TARGET_DIR="${1:-/tmp/swarm_cleanup}"
+REPO_URL="https://github.com/tanngoc93/swarm-stackhouse.git"
+TARGET_DIR="${1:-/tmp/swarm-stackhouse}"
 BRANCH="${2:-main}"
 
 # Deployment ENV (can be overridden by caller)


### PR DESCRIPTION
## Summary
- Rename ensure script to `ensure_swarm_stackhouse_and_deploy.sh`
- Replace old `swarm_cleanup` paths and URLs with `swarm-stackhouse`
- Update docs and cleanup stack defaults for new repository name

## Testing
- `bash -n deploy_and_cleanup.sh manual_rollback.sh scripts/*.sh ensure_swarm_stackhouse_and_deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b97078df04832b9c5df39646464f32