### PR TITLE
Move deployment script and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
 Run basic syntax checks before submitting changes:
 
 ```bash
-bash -n deploy_and_cleanup.sh manual_rollback.sh scripts/*.sh ensure_swarm_stackhouse_and_deploy.sh
+bash -n scripts/*.sh manual_rollback.sh ensure_swarm_stackhouse_and_deploy.sh
 ```
 
 ## License

--- a/ensure_swarm_stackhouse_and_deploy.sh
+++ b/ensure_swarm_stackhouse_and_deploy.sh
@@ -4,7 +4,7 @@
 # Purpose:
 #   - Ensure the public repo "swarm-stackhouse" exists locally (HTTPS clone).
 #   - If the remote branch has a newer commit, re-clone a fresh copy (atomic replace).
-#   - Run the repo's ./deploy_and_cleanup.sh with the provided ENV configuration.
+#   - Run the repo's ./scripts/deploy_and_cleanup.sh with the provided ENV configuration.
 #
 # Usage:
 #   ./ensure_swarm_stackhouse_and_deploy.sh [TARGET_DIR] [BRANCH]
@@ -79,7 +79,7 @@ clone_fresh() {
 
   # Make commonly used scripts executable (idempotent)
   ensure_executable_if_exists "$tmpdir/repo/scripts/run_swarm_cleanup.sh"
-  ensure_executable_if_exists "$tmpdir/repo/deploy_and_cleanup.sh"
+  ensure_executable_if_exists "$tmpdir/repo/scripts/deploy_and_cleanup.sh"
 
   # Atomic replace
   mkdir -p "$(dirname "$TARGET_DIR")"
@@ -94,11 +94,11 @@ clone_fresh() {
 }
 
 run_deploy() {
-  # Execute deploy_and_cleanup.sh with the configured ENV
-  local deploy_script="$TARGET_DIR/deploy_and_cleanup.sh"
+  # Execute scripts/deploy_and_cleanup.sh with the configured ENV
+  local deploy_script="$TARGET_DIR/scripts/deploy_and_cleanup.sh"
   [[ -x "$deploy_script" ]] || abort "$deploy_script not found or not executable"
 
-  log "🚀 Running deploy_and_cleanup.sh with ENV:"
+  log "🚀 Running scripts/deploy_and_cleanup.sh with ENV:"
   log "    IMAGE_TAG  = $IMAGE_TAG"
   log "    IMAGE_REPO = $IMAGE_REPO"
   log "    STACK_NAME = $STACK_NAME"
@@ -140,7 +140,7 @@ main() {
       log "✅ Repo is up to date."
       # Still ensure scripts are executable (idempotent)
       ensure_executable_if_exists "$TARGET_DIR/scripts/run_swarm_cleanup.sh"
-      ensure_executable_if_exists "$TARGET_DIR/deploy_and_cleanup.sh"
+      ensure_executable_if_exists "$TARGET_DIR/scripts/deploy_and_cleanup.sh"
     fi
   fi
 

--- a/manual_rollback.sh
+++ b/manual_rollback.sh
@@ -37,7 +37,7 @@ main() {
   if [[ ! -f "$DIGEST_FILE" ]]; then
     {
       echo "Digest log not found: $DIGEST_FILE"
-      echo "Run deploy_and_cleanup.sh to generate it or set DIGEST_FILE to an existing log."
+      echo "Run scripts/deploy_and_cleanup.sh to generate it or set DIGEST_FILE to an existing log."
     } >&2
     exit 1
   fi

--- a/scripts/deploy_and_cleanup.sh
+++ b/scripts/deploy_and_cleanup.sh
@@ -10,10 +10,10 @@ set -euo pipefail
 #   STACK_FILE       Path to stack file (required)
 #   LOG_FILE         Output log (default: /var/log/deploy_${STACK_NAME}_uniq.log)
 #   LOCK_FILE        PID lock file (default: /tmp/deploy_${STACK_NAME}_uniq.pid)
-#   CLEANUP_SCRIPT      Script to run after deployment (default: ./scripts/run_swarm_cleanup.sh)
-#   CLEANUP_STACK_FILE  Stack file used by the cleanup script (default: ./docker/cleanup-stack.yml)
+#   CLEANUP_SCRIPT      Script to run after deployment (default: ./run_swarm_cleanup.sh)
+#   CLEANUP_STACK_FILE  Stack file used by the cleanup script (default: ../docker/cleanup-stack.yml)
 #   CLEANUP_STACK_NAME  Stack name used by the cleanup script (default: swarm-cleanup)
-#   DIGEST_DIR        Directory to store image digest logs (default: ./digests)
+#   DIGEST_DIR        Directory to store image digest logs (default: ../digests)
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$STACK_NAME|$IMAGE_TAG] $1"; }
 require() { command -v "$1" >/dev/null 2>&1 || { echo "command not found: $1" >&2; exit 1; }; }
@@ -26,10 +26,11 @@ main() {
   LOG_FILE="${LOG_FILE:-/var/log/deploy_${STACK_NAME}_uniq.log}"
   LOCK_FILE="${LOCK_FILE:-/tmp/deploy_${STACK_NAME}_uniq.pid}"
   SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-  CLEANUP_SCRIPT="${CLEANUP_SCRIPT:-$SCRIPT_DIR/scripts/run_swarm_cleanup.sh}"
-  CLEANUP_STACK_FILE="${CLEANUP_STACK_FILE:-$SCRIPT_DIR/docker/cleanup-stack.yml}"
+  REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." &>/dev/null && pwd)"
+  CLEANUP_SCRIPT="${CLEANUP_SCRIPT:-$SCRIPT_DIR/run_swarm_cleanup.sh}"
+  CLEANUP_STACK_FILE="${CLEANUP_STACK_FILE:-$REPO_ROOT/docker/cleanup-stack.yml}"
   CLEANUP_STACK_NAME="${CLEANUP_STACK_NAME:-swarm-cleanup}"
-  DIGEST_DIR="${DIGEST_DIR:-$SCRIPT_DIR/digests}"
+  DIGEST_DIR="${DIGEST_DIR:-$REPO_ROOT/digests}"
 
   if [[ -z "$IMAGE_REPO" || -z "$STACK_NAME" || -z "$STACK_FILE" ]]; then
     echo "IMAGE_REPO, STACK_NAME and STACK_FILE must be set" >&2


### PR DESCRIPTION
## Summary
- move deploy_and_cleanup.sh into scripts directory
- adjust cleanup and digest paths to use repo root
- update docs and scripts to call new script location

## Testing
- `bash -n scripts/deploy_and_cleanup.sh scripts/run_swarm_cleanup.sh scripts/cleanup_docker_images.sh manual_rollback.sh ensure_swarm_stackhouse_and_deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b971ff7cc4832b881a6fa737095600