### PR TITLE
Move manual rollback script into scripts directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
    To roll back manually, create another script (e.g. `rollback_swarm.sh`) containing:
 
    ```bash
-   IMAGE_REPO=myorg/myapp STACK_NAME=app_stack bash /tmp/swarm-stackhouse/manual_rollback.sh
+   IMAGE_REPO=myorg/myapp STACK_NAME=app_stack bash /tmp/swarm-stackhouse/scripts/manual_rollback.sh
    ```
 
    Make it executable with `chmod +x rollback_swarm.sh`.
@@ -52,7 +52,7 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
 Run basic syntax checks before submitting changes:
 
 ```bash
-bash -n scripts/*.sh manual_rollback.sh ensure_swarm_stackhouse_and_deploy.sh
+bash -n scripts/*.sh ensure_swarm_stackhouse_and_deploy.sh
 ```
 
 ## License

--- a/ensure_swarm_stackhouse_and_deploy.sh
+++ b/ensure_swarm_stackhouse_and_deploy.sh
@@ -80,6 +80,7 @@ clone_fresh() {
   # Make commonly used scripts executable (idempotent)
   ensure_executable_if_exists "$tmpdir/repo/scripts/run_swarm_cleanup.sh"
   ensure_executable_if_exists "$tmpdir/repo/scripts/deploy_and_cleanup.sh"
+  ensure_executable_if_exists "$tmpdir/repo/scripts/manual_rollback.sh"
 
   # Atomic replace
   mkdir -p "$(dirname "$TARGET_DIR")"
@@ -141,6 +142,7 @@ main() {
       # Still ensure scripts are executable (idempotent)
       ensure_executable_if_exists "$TARGET_DIR/scripts/run_swarm_cleanup.sh"
       ensure_executable_if_exists "$TARGET_DIR/scripts/deploy_and_cleanup.sh"
+      ensure_executable_if_exists "$TARGET_DIR/scripts/manual_rollback.sh"
     fi
   fi
 

--- a/scripts/manual_rollback.sh
+++ b/scripts/manual_rollback.sh
@@ -4,21 +4,22 @@ set -euo pipefail
 # manual_rollback.sh - Roll back services in a Docker Swarm stack to a previously deployed image digest.
 #
 # Usage:
-#   STACK_NAME=my_stack IMAGE_REPO=myorg/myimage ./manual_rollback.sh
-#   STACK_NAME=my_stack IMAGE_REPO=myorg/myimage TARGET_DIGEST=sha256:deadbeef ./manual_rollback.sh
+#   STACK_NAME=my_stack IMAGE_REPO=myorg/myimage ./scripts/manual_rollback.sh
+#   STACK_NAME=my_stack IMAGE_REPO=myorg/myimage TARGET_DIGEST=sha256:deadbeef ./scripts/manual_rollback.sh
 #
 # Environment variables (with defaults):
 #   IMAGE_REPO    Image repository (default: myorg/myapp)
 #   STACK_NAME    Stack name (default: app_stack)
-#   DIGEST_DIR    Directory storing digest logs (default: ./digests)
-#   DIGEST_FILE   File storing digests (default: ./digests/app_stack_image_digests.log)
+#   DIGEST_DIR    Directory storing digest logs (default: ../digests)
+#   DIGEST_FILE   File storing digests (default: ../digests/app_stack_image_digests.log)
 #   TARGET_DIGEST Digest to roll back to (optional; prompts if unset)
 
 # -------- Config (defaults) --------
 IMAGE_REPO="${IMAGE_REPO:-myorg/myapp}"
 STACK_NAME="${STACK_NAME:-app_stack}"
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-DIGEST_DIR="${DIGEST_DIR:-$SCRIPT_DIR/digests}"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." &>/dev/null && pwd)"
+DIGEST_DIR="${DIGEST_DIR:-$REPO_ROOT/digests}"
 DIGEST_FILE="${DIGEST_FILE:-$DIGEST_DIR/${STACK_NAME}_image_digests.log}"
 TARGET_DIGEST="${TARGET_DIGEST:-}"
 LOG_TAG="rollback"


### PR DESCRIPTION
## Summary
- move manual rollback helper into scripts folder
- update README and defaults to reference new script path
- ensure manual rollback script is made executable when repo is cloned or refreshed

## Testing
- `bash -n scripts/*.sh ensure_swarm_stackhouse_and_deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9735270a8832bae07a50848071e7a