### PR TITLE
chore: rename deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
 
 1. **Create a deployment script**
 
-   On the Swarm manager node, create a shell script such as `deploy_swarm.sh` and copy the contents of `ensure_swarm_stackhouse_and_deploy.sh` from this repository into it. Make the script executable:
+   On the Swarm manager node, create a shell script such as `deploy_swarm.sh` and copy the contents of `stackhouse_deploy_and_clean.sh` from this repository into it. Make the script executable:
 
    ```bash
    chmod +x deploy_swarm.sh
@@ -52,7 +52,7 @@ Simple Bash utilities for managing Docker Swarm stacks and cleaning up unused im
 Run basic syntax checks before submitting changes:
 
 ```bash
-bash -n scripts/*.sh ensure_swarm_stackhouse_and_deploy.sh
+bash -n scripts/*.sh stackhouse_deploy_and_clean.sh
 ```
 
 ## License

--- a/stackhouse_deploy_and_clean.sh
+++ b/stackhouse_deploy_and_clean.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# ensure_swarm_stackhouse_and_deploy.sh
+# stackhouse_deploy_and_clean.sh
 #
 # Purpose:
 #   - Ensure the public repo "swarm-stackhouse" exists locally (HTTPS clone).
@@ -7,7 +7,7 @@
 #   - Run the repo's ./scripts/deploy_and_cleanup.sh with the provided ENV configuration.
 #
 # Usage:
-#   ./ensure_swarm_stackhouse_and_deploy.sh [TARGET_DIR] [BRANCH]
+#   ./stackhouse_deploy_and_clean.sh [TARGET_DIR] [BRANCH]
 #
 #   TARGET_DIR (optional) : destination directory (default: /tmp/swarm-stackhouse)
 #   BRANCH     (optional) : git branch to track (default: main)


### PR DESCRIPTION
## Summary
- rename ensure_swarm_stackhouse_and_deploy.sh to stackhouse_deploy_and_clean.sh
- update README references and usage instructions

## Testing
- `bash -n scripts/*.sh stackhouse_deploy_and_clean.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b974ad9a48832ba8cb1cda0d0be420