### PR TITLE
fix: ensure setup script injects custom values

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 cat <<'DESC'
 =====================================================================
 Stackhouse deploy setup
@@ -44,10 +46,10 @@ rep_file=$(escape_sed "$STACK_FILE")
 timestamp=$(date +%s)
 output="deploy_${STACK_NAME}_${timestamp}.sh"
 
-cp stackhouse_deploy_and_clean.sh "$output"
-sed -i "s|IMAGE_REPO=\"\\\${IMAGE_REPO:-myorg/myapp}\"|IMAGE_REPO=\"$rep_repo\"|" "$output"
-sed -i "s|STACK_NAME=\"\\\${STACK_NAME:-app_stack}\"|STACK_NAME=\"$rep_name\"|" "$output"
-sed -i "s|STACK_FILE=\"\\\${STACK_FILE:-/root/docker/app-stack.yml}\"|STACK_FILE=\"$rep_file\"|" "$output"
+cp "$SCRIPT_DIR/stackhouse_deploy_and_clean.sh" "$output"
+sed -i "s|^IMAGE_REPO=.*$|IMAGE_REPO=\"$rep_repo\"|" "$output"
+sed -i "s|^STACK_NAME=.*$|STACK_NAME=\"$rep_name\"|" "$output"
+sed -i "s|^STACK_FILE=.*$|STACK_FILE=\"$rep_file\"|" "$output"
 chmod +x "$output"
 
 echo "\n✅ Created deployment script: $output"

--- a/stackhouse_deploy_and_clean.sh
+++ b/stackhouse_deploy_and_clean.sh
@@ -32,6 +32,8 @@ BRANCH="${2:-main}"
 
 # Deployment ENV (can be overridden by caller)
 IMAGE_TAG="${IMAGE_TAG:-latest}"
+# The following defaults may be overridden by setup.sh when generating
+# a customized deployment script.
 IMAGE_REPO="${IMAGE_REPO:-myorg/myapp}"
 STACK_NAME="${STACK_NAME:-app_stack}"
 STACK_FILE="${STACK_FILE:-/root/docker/app-stack.yml}"


### PR DESCRIPTION
## Summary
- make `setup.sh` copy template reliably by detecting its own directory
- broaden variable replacement so generated deploy scripts embed user inputs
- clarify that defaults in `stackhouse_deploy_and_clean.sh` may be overridden

## Testing
- `bash -n setup.sh stackhouse_deploy_and_clean.sh`
- ran `../setup.sh` from a subdirectory to verify custom values were written


------
https://chatgpt.com/codex/tasks/task_e_68b9791cb838832b9574d632145e8d04