### PR TITLE
Fix setup script prompts to work when piped

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,9 +19,13 @@ prompt_non_empty() {
   # Prompt the user until a non-empty value is entered
   local var_name="$1" prompt="$2" value
   while true; do
-    read -rp "$prompt" value
+    # Read directly from the user's TTY so piping the script via curl works
+    if ! read -rp "$prompt" value </dev/tty; then
+      echo "Input aborted" >&2
+      exit 1
+    fi
     [[ -n "$value" ]] && { printf '%s' "$value"; return; }
-    echo "$var_name cannot be empty."
+    echo "$var_name cannot be empty." >&2
   done
 }
 


### PR DESCRIPTION
## Summary
- read user prompts from /dev/tty so `setup.sh` works when invoked via curl pipeline
- handle aborted input gracefully

## Testing
- `bash -n scripts/*.sh stackhouse_deploy_and_clean.sh setup.sh`
- `cat setup.sh | bash` *(fails to download stackhouse_deploy_and_clean.sh with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b97f31d94c832b9285d5c9e53f2eb9