### PR TITLE
Improve README clarity and setup script documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,28 @@
 # Swarm Stackhouse
 
-Bash utilities for deploying Docker Swarm stacks, cleaning old images and
-rolling back by digest.
+Collection of Bash utilities to deploy Docker Swarm stacks, clean up old images, and roll back services by image digest.
+
+## Requirements
+
+- Bash
+- Docker CLI available in `PATH`
+- Access to a Docker daemon in Swarm mode
 
 ## Quick start
 
 1. **Generate a deployment script**
 
-   Run the setup script directly from the internet and answer the prompts:
+   Run the setup script from the internet and answer the prompts:
 
    ```bash
    bash <(curl -fsSL https://raw.githubusercontent.com/tanngoc93/swarm-stackhouse/main/setup.sh)
    ```
 
-   A file named `deploy_<STACK_NAME>_<timestamp>.sh` will be created in the
-   current directory with your values baked in.
+   The command creates `deploy_<STACK_NAME>_<timestamp>.sh` in the current directory with your answers baked in.
 
-2. **Deploy**
+2. **Deploy the stack**
 
-   Execute the generated script to deploy or update your stack. Optionally
-   override the image tag at runtime (defaults to `latest`):
+   Execute the generated script to deploy or update your stack. Optionally override the image tag at runtime (defaults to `latest`):
 
    ```bash
    IMAGE_TAG=v1 ./deploy_<STACK_NAME>_<timestamp>.sh
@@ -27,8 +30,7 @@ rolling back by digest.
 
 ## Logs and debugging
 
-* Logs are written to `/var/log/deploy_<STACK_NAME>_uniq.log` by default.
-  View them with:
+* Logs are written to `/var/log/deploy_<STACK_NAME>_uniq.log`. Tail them with:
 
   ```bash
   tail -f /var/log/deploy_<STACK_NAME>_uniq.log
@@ -42,35 +44,26 @@ rolling back by digest.
 
 ## Manual rollback
 
-The repository provides `scripts/manual_rollback.sh` to roll back services to a
-previously deployed image digest. Run it like this:
+Use `scripts/manual_rollback.sh` to roll back services to a previously deployed image digest:
 
 ```bash
 STACK_NAME=my_stack IMAGE_REPO=myorg/myimage \
   bash /tmp/swarm-stackhouse/scripts/manual_rollback.sh
 ```
 
-You will be prompted to select a stored digest. Set `TARGET_DIGEST` to skip the
-prompt.
+You will be prompted to select a stored digest. Set `TARGET_DIGEST` to skip the prompt.
 
-You may create a convenience wrapper (e.g. `rollback_swarm.sh`) containing the
-above command and make it executable with `chmod +x rollback_swarm.sh`.
+You can create a wrapper (e.g. `rollback_swarm.sh`) containing the above command and make it executable with `chmod +x rollback_swarm.sh`.
 
-## Running rollback
+## Roll back to a specific digest
 
-To roll back using a specific digest:
+To roll back using a known digest:
 
 ```bash
 STACK_NAME=my_stack IMAGE_REPO=myorg/myimage \
   TARGET_DIGEST=sha256:deadbeef \
   bash /tmp/swarm-stackhouse/scripts/manual_rollback.sh
 ```
-
-## Requirements
-
-- Bash
-- Docker CLI available in `PATH`
-- Access to a Docker daemon in Swarm mode
 
 ## Development
 
@@ -83,4 +76,3 @@ bash -n scripts/*.sh stackhouse_deploy_and_clean.sh setup.sh
 ## License
 
 This project is provided under the MIT License.
-

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 ## setup.sh
-# Interactive helper that fetches the latest `stackhouse_deploy_and_clean.sh`
-# from GitHub and embeds user supplied variables into a ready-to-run
-# deployment script. All prompts are interactive to keep usage simple.
+# Interactive helper that downloads the latest stackhouse_deploy_and_clean.sh
+# and produces a ready-to-run deployment script with user-provided values.
+# All prompts are interactive to keep usage simple.
 
 set -euo pipefail
 
@@ -29,10 +29,17 @@ prompt_non_empty() {
   done
 }
 
-require curl
-require sed
+escape_sed() {
+  # Escape characters that have special meaning in sed
+  printf '%s' "$1" | sed -e 's/[\\/|&]/\\&/g'
+}
 
-cat <<'DESC'
+main() {
+  # Validate required tools
+  require curl
+  require sed
+
+  cat <<'DESC'
 =====================================================================
 Stackhouse deploy setup
 ---------------------------------------------------------------------
@@ -46,35 +53,39 @@ this directory with these values baked in.
 =====================================================================
 DESC
 
-#----- prompt for settings -------------------------------------------
-IMAGE_REPO=$(prompt_non_empty "IMAGE_REPO" "IMAGE_REPO: ")
-STACK_NAME=$(prompt_non_empty "STACK_NAME" "STACK_NAME: ")
-STACK_FILE=$(prompt_non_empty "STACK_FILE" "STACK_FILE: ")
+  # Prompt for settings
+  IMAGE_REPO=$(prompt_non_empty "IMAGE_REPO" "IMAGE_REPO: ")
+  STACK_NAME=$(prompt_non_empty "STACK_NAME" "STACK_NAME: ")
+  STACK_FILE=$(prompt_non_empty "STACK_FILE" "STACK_FILE: ")
 
-# Escape user input for safe sed replacement
-escape_sed() { printf '%s' "$1" | sed -e 's/[\\/|&]/\\&/g'; }
+  # Escape user input for safe sed replacement
+  rep_repo=$(escape_sed "$IMAGE_REPO")
+  rep_name=$(escape_sed "$STACK_NAME")
+  rep_file=$(escape_sed "$STACK_FILE")
 
-rep_repo=$(escape_sed "$IMAGE_REPO")
-rep_name=$(escape_sed "$STACK_NAME")
-rep_file=$(escape_sed "$STACK_FILE")
+  # Determine output file
+  local timestamp output
+  timestamp=$(date +%s)
+  output="deploy_${STACK_NAME}_${timestamp}.sh"
 
-timestamp=$(date +%s)
-output="deploy_${STACK_NAME}_${timestamp}.sh"
-
-echo "⬇️  Fetching latest stackhouse_deploy_and_clean.sh from GitHub..."
-curl -fsSL \
-  https://raw.githubusercontent.com/tanngoc93/swarm-stackhouse/main/stackhouse_deploy_and_clean.sh \
-  -o "$output" || {
+  echo "⬇️  Fetching latest stackhouse_deploy_and_clean.sh from GitHub..."
+  curl -fsSL \
+    https://raw.githubusercontent.com/tanngoc93/swarm-stackhouse/main/stackhouse_deploy_and_clean.sh \
+    -o "$output" || {
     echo "❌ Failed to download stackhouse_deploy_and_clean.sh"
     exit 1
   }
 
-# Replace defaults with user input (keeping ${VAR:-...} format)
-sed -i.bak "s|^IMAGE_REPO=.*|IMAGE_REPO=\"\${IMAGE_REPO:-$rep_repo}\"|" "$output"
-sed -i.bak "s|^STACK_NAME=.*|STACK_NAME=\"\${STACK_NAME:-$rep_name}\"|" "$output"
-sed -i.bak "s|^STACK_FILE=.*|STACK_FILE=\"\${STACK_FILE:-$rep_file}\"|" "$output"
-rm -f "$output.bak"
+  # Replace defaults with user input (keeping ${VAR:-...} format)
+  sed -i.bak \
+    -e "s|^IMAGE_REPO=.*|IMAGE_REPO=\\"\\${IMAGE_REPO:-$rep_repo}\\"|" \
+    -e "s|^STACK_NAME=.*|STACK_NAME=\\"\\${STACK_NAME:-$rep_name}\\"|" \
+    -e "s|^STACK_FILE=.*|STACK_FILE=\\"\\${STACK_FILE:-$rep_file}\\"|" \
+    "$output"
+  rm -f "$output.bak"
+  chmod +x "$output"
 
-chmod +x "$output"
+  echo -e "\n✅ Created deployment script: $output"
+}
 
-echo -e "\n✅ Created deployment script: $output"
+main "$@"


### PR DESCRIPTION
## Summary
- Clarify README with requirements, step-by-step quick start, and rollback details
- Refactor `setup.sh` with clearer comments and structured main workflow

## Testing
- `bash -n scripts/*.sh stackhouse_deploy_and_clean.sh setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b981fd7a14832ba55ae49582f33da8