### PR TITLE
feat: log to repo directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 digests/
 *_image_digests.log
 
+# Deployment logs
+log/
+

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Collection of Bash utilities to deploy Docker Swarm stacks, clean up old images,
 
 ## Logs and debugging
 
-* Logs are written to `/var/log/deploy_<STACK_NAME>_uniq.log`. Tail them with:
+* Logs are written to `log/deploy_<STACK_NAME>_uniq.log` in the repository root. Tail them with:
 
   ```bash
-  tail -f /var/log/deploy_<STACK_NAME>_uniq.log
+  tail -f log/deploy_<STACK_NAME>_uniq.log
   ```
 
 * For verbose debugging output, run the deployment script with `bash -x`:

--- a/scripts/deploy_and_cleanup.sh
+++ b/scripts/deploy_and_cleanup.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   IMAGE_REPO       Repository for the image (required)
 #   STACK_NAME       Name of the stack (required)
 #   STACK_FILE       Path to stack file (required)
-#   LOG_FILE         Output log (default: /var/log/deploy_${STACK_NAME}_uniq.log)
+#   LOG_FILE         Output log (default: <repo_root>/log/deploy_${STACK_NAME}_uniq.log)
 #   LOCK_FILE        PID lock file (default: /tmp/deploy_${STACK_NAME}_uniq.pid)
 #   CLEANUP_SCRIPT      Script to run after deployment (default: ./run_swarm_cleanup.sh)
 #   CLEANUP_STACK_FILE  Stack file used by the cleanup script (default: ../docker/cleanup-stack.yml)
@@ -23,14 +23,16 @@ main() {
   IMAGE_REPO="${IMAGE_REPO:-}"
   STACK_NAME="${STACK_NAME:-}"
   STACK_FILE="${STACK_FILE:-}"
-  LOG_FILE="${LOG_FILE:-/var/log/deploy_${STACK_NAME}_uniq.log}"
-  LOCK_FILE="${LOCK_FILE:-/tmp/deploy_${STACK_NAME}_uniq.pid}"
   SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
   REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." &>/dev/null && pwd)"
+  LOG_FILE="${LOG_FILE:-$REPO_ROOT/log/deploy_${STACK_NAME}_uniq.log}"
+  LOCK_FILE="${LOCK_FILE:-/tmp/deploy_${STACK_NAME}_uniq.pid}"
   CLEANUP_SCRIPT="${CLEANUP_SCRIPT:-$SCRIPT_DIR/run_swarm_cleanup.sh}"
   CLEANUP_STACK_FILE="${CLEANUP_STACK_FILE:-$REPO_ROOT/docker/cleanup-stack.yml}"
   CLEANUP_STACK_NAME="${CLEANUP_STACK_NAME:-swarm-cleanup}"
   DIGEST_DIR="${DIGEST_DIR:-$REPO_ROOT/digests}"
+
+  mkdir -p "$(dirname "$LOG_FILE")"
 
   if [[ -z "$IMAGE_REPO" || -z "$STACK_NAME" || -z "$STACK_FILE" ]]; then
     echo "IMAGE_REPO, STACK_NAME and STACK_FILE must be set" >&2


### PR DESCRIPTION
## Summary
- store deploy logs under repo `log/` directory by default
- document new log location and ignore generated logs

## Testing
- `bash -n scripts/*.sh stackhouse_deploy_and_clean.sh setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b98d888f34832bb29f0b650ee8382e