### PR TITLE
Preserve digest history across repo refreshes

### DIFF
--- a/stackhouse_deploy_and_clean.sh
+++ b/stackhouse_deploy_and_clean.sh
@@ -84,6 +84,12 @@ refresh_repo() {
   ensure_executable_if_exists "$tmpdir/repo/scripts/deploy_and_cleanup.sh"
   ensure_executable_if_exists "$tmpdir/repo/scripts/manual_rollback.sh"
 
+  # Preserve existing digest logs (if any)
+  if [[ -d "$TARGET_DIR/digests" ]]; then
+    cp -r "$TARGET_DIR/digests" "$tmpdir/repo/" 2>/dev/null || true
+    log "🗃️  Preserved existing digests directory."
+  fi
+
   # Atomic replace of the target directory
   mkdir -p "$(dirname "$TARGET_DIR")"
   if [[ -e "$TARGET_DIR" ]]; then


### PR DESCRIPTION
## Summary
- Keep existing `digests` directory when refreshing repo so up to five previous image digests persist across deployments

## Testing
- `bash -n scripts/*.sh stackhouse_deploy_and_clean.sh setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b98eded8ec832bbd315f4f5805d5a7