### PR TITLE
Add sample Docker Swarm stack configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Collection of Bash utilities to deploy Docker Swarm stacks, clean up old images,
 ## Sample stack file
 
 An example Docker Swarm stack configuration is provided in `swarm-stack-sample/sample-stack.yml`.
-Use it as a starting point and replace placeholder values like `exampleorg/myapp:latest`
-and `example.com` with settings for your environment.
+The `image` field supports overriding via an `IMAGE_NAME` environment variable and falls back to
+`exampleorg/myapp:latest` if none is provided. Replace this placeholder along with `example.com`
+and other sample values with settings for your environment.
 
 ## Logs and debugging
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Collection of Bash utilities to deploy Docker Swarm stacks, clean up old images,
    IMAGE_TAG=v1 ./deploy_<STACK_NAME>_<timestamp>.sh
    ```
 
+## Sample stack file
+
+An example Docker Swarm stack configuration is provided in `swarm-stack-sample/sample-stack.yml`.
+Use it as a starting point and replace placeholder values like `exampleorg/myapp:latest`
+and `example.com` with settings for your environment.
+
 ## Logs and debugging
 
 * Logs are written to `log/deploy_<STACK_NAME>_uniq.log` in the repository root. Tail them with:

--- a/swarm-stack-sample/sample-stack.yml
+++ b/swarm-stack-sample/sample-stack.yml
@@ -1,0 +1,61 @@
+networks:
+  public-network:
+    driver: overlay
+    external: true
+
+services:
+  web:
+    image: "exampleorg/myapp:latest"
+    working_dir: /app
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    environment:
+      DB_POOL: "5"
+      DB_HOST: "db.example"
+      DB_PORT: "5432"
+      DB_USER: "demo"
+      DB_PASSWORD: "secret"
+      DB_PRODUCTION: "false"
+      REDIS_URL: "redis://redis.example:6379/0"
+      REDIS_CACHE_URL: "redis://redis.example:6379/1"
+      RAILS_ENV: "production"
+      PORT: "3000"
+    command: /bin/sh "/app/start.sh"
+    deploy:
+      mode: replicated
+      replicas: 2
+      labels:
+        - "traefik.enable=true"
+        - "traefik.docker.network=public-network"
+        # Middleware: redirect
+        - "traefik.http.middlewares.web-redirect.redirectscheme.scheme=https"
+        # HTTP Router
+        - "traefik.http.routers.web-http.rule=Host(`example.com`)"
+        - "traefik.http.routers.web-http.entrypoints=web"
+        - "traefik.http.routers.web-http.middlewares=web-redirect"
+        - "traefik.http.routers.web-http.service=web-svc"
+        # HTTPS Router
+        - "traefik.http.routers.web-secured.rule=Host(`example.com`)"
+        - "traefik.http.routers.web-secured.entrypoints=websecured"
+        - "traefik.http.routers.web-secured.tls.certresolver=letsencrypt"
+        - "traefik.http.routers.web-secured.service=web-svc"
+        # Service port
+        - "traefik.http.services.web-svc.loadbalancer.server.port=3000"
+      update_config:
+        parallelism: 2
+        delay: 10s
+        failure_action: rollback
+        monitor: 10s
+        order: start-first
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+    stop_grace_period: 10s
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - public-network

--- a/swarm-stack-sample/sample-stack.yml
+++ b/swarm-stack-sample/sample-stack.yml
@@ -5,7 +5,7 @@ networks:
 
 services:
   web:
-    image: "exampleorg/myapp:latest"
+    image: "${IMAGE_NAME:-exampleorg/myapp:latest}"
     working_dir: /app
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"


### PR DESCRIPTION
## Summary
- move stack example to `swarm-stack-sample/` for clarity
- strip private network and replace image, domain, and environment values with placeholders
- document new sample location in README

## Testing
- `bash -n scripts/*.sh stackhouse_deploy_and_clean.sh setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b997db1f54832b9964a3c66a1fe596