### PR TITLE
Improve logging for mismatched stack service tags

### DIFF
--- a/scripts/deploy_and_cleanup.sh
+++ b/scripts/deploy_and_cleanup.sh
@@ -68,20 +68,20 @@ main() {
     skip_deploy=false
     existing_services=($(docker stack services "$STACK_NAME" --format '{{.Name}}' 2>/dev/null))
     if [[ "$IMAGE_TAG" != "latest" && ${#existing_services[@]} -gt 0 ]]; then
-      all_services_match=true
+      mismatched_services=()
       for service_name in "${existing_services[@]}"; do
         current_image=$(docker service inspect "$service_name" -f '{{index .Spec.TaskTemplate.ContainerSpec.Image}}' 2>/dev/null || true)
         current_tag=$(echo "$current_image" | sed -e 's/@.*//' | awk -F':' '{print $NF}')
         if [[ "$current_tag" != "$IMAGE_TAG" ]]; then
-          log "🔎 Service $service_name running different tag ($current_tag). Deploy needed."
-          all_services_match=false
-          break
+          mismatched_services+=("$service_name ($current_tag)")
         fi
       done
 
-      if $all_services_match; then
+      if [[ ${#mismatched_services[@]} -eq 0 ]]; then
         log "♻️ All services already running image tag $IMAGE_TAG. Skipping deploy/update."
         skip_deploy=true
+      else
+        log "🔎 Services needing deploy (expected $IMAGE_TAG): ${mismatched_services[*]}"
       fi
     fi
 

--- a/scripts/deploy_and_cleanup.sh
+++ b/scripts/deploy_and_cleanup.sh
@@ -66,7 +66,7 @@ main() {
     log "📄 Stack file: $STACK_FILE"
 
     skip_deploy=false
-    existing_services=($(docker stack services "$STACK_NAME" --format '{{.Name}}' 2>/dev/null))
+    existing_services=($(docker stack services "$STACK_NAME" --format '{{.Name}}' 2>/dev/null || true))
     if [[ "$IMAGE_TAG" != "latest" && ${#existing_services[@]} -gt 0 ]]; then
       mismatched_services=()
       for service_name in "${existing_services[@]}"; do


### PR DESCRIPTION
## Summary
- report all services that need redeploy when their image tags differ from the target
- keep the skip notice when every service already matches the target image tag

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69203284c250832bb57ba846b62c1a07)