### PR TITLE
Fix stack_name visibility for cleanup script trap

### DIFF
--- a/scripts/run_swarm_cleanup.sh
+++ b/scripts/run_swarm_cleanup.sh
@@ -13,12 +13,16 @@ set -euo pipefail
 log() { printf '%s\n' "$*"; }
 require() { command -v "$1" >/dev/null 2>&1 || { log "command not found: $1"; exit 1; }; }
 
+# Globals used by cleanup trap; populated in main
+stack_name=""
+deployed=0
+
 main() {
   require docker
 
   local script_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
   local stack_file="${STACK_FILE:-$script_dir/../docker/cleanup-stack.yml}"
-  local stack_name="${STACK_NAME:-swarm-cleanup}"
+  stack_name="${STACK_NAME:-swarm-cleanup}"
   local image_repo="${IMAGE_REPO:-}"
   local wait_timeout=${WAIT_TIMEOUT:-300}
   local poll_interval=${POLL_INTERVAL:-3}


### PR DESCRIPTION
## Summary
- ensure the cleanup trap has access to stack_name/deployed by defining them globally before use

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69214e2fb2a4832b841a8b6e40440b4c)